### PR TITLE
Downgrade leaflet version to fix mysterious console error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,9 +36,14 @@
       "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
     "leaflet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.3.1.tgz",
-      "integrity": "sha512-adQOIzh+bfdridLM1xIgJ9VnJbAUY3wqs/ueF+ITla+PLQ1z47USdBKUf+iD9FuUA8RtlT6j6hZBfZoA6mW+XQ=="
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.7.tgz",
+      "integrity": "sha1-HjUrpU5j0HZFH6NjyQCJDLLPde4="
+    },
+    "popper.js": {
+      "version": "1.12.9",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.12.9.tgz",
+      "integrity": "sha1-DfvC3/lsRRuzMu3Pz6r1ZtMx1bM="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "angular-leaflet-directive": "^0.10.0",
     "bootstrap": "^4.0.0",
     "jquery": "^3.3.1",
-    "leaflet": "^1.3.1"
+    "leaflet": "^0.7.2",
+    "popper.js": "^1.12.9"
   }
 }


### PR DESCRIPTION
Was giving an error when adding a new marker. Said "file not found" and
would not display the marker's shadow. We found that downgrading the
leaflet version solved the issue.

Also added popper to illiminate warning when running npm install.